### PR TITLE
CORE-490: Invalid user agent

### DIFF
--- a/packages/react-native-ueat/package.json
+++ b/packages/react-native-ueat/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-ueat",
   "description": "Integrate UEAT food ordering into your react-native application",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "main": "cjs/index.js",
   "module": "es6/index.js",
   "repository": "git@github.com:UEAT/react-native-ueat.git",

--- a/packages/react-native-ueat/src/UEATRestaurant.tsx
+++ b/packages/react-native-ueat/src/UEATRestaurant.tsx
@@ -18,7 +18,10 @@ interface Props {
   onLeave?: () => void;
 }
 
-const userAgent = `${DeviceInfo.getUserAgent()} - UEAT Native App - ${DeviceInfo.getBundleId()} - ${DeviceInfo.getVersion()}`;
+let deviceUserAgent = 'Unknown';
+DeviceInfo.getUserAgent()
+  .then(userAgent => (deviceUserAgent = userAgent))
+  .catch(() => (deviceUserAgent = 'Unknown'));
 
 function UEATRestaurant({
   apiKey,
@@ -73,7 +76,7 @@ function UEATRestaurant({
   return (
     <View style={styles.container}>
       <WebView
-        userAgent={userAgent}
+        userAgent={`${deviceUserAgent} - UEAT Native App - ${DeviceInfo.getBundleId()} - ${DeviceInfo.getVersion()}`}
         bounces={false}
         originWhitelist={['*']}
         source={{ uri }}


### PR DESCRIPTION
`DeviceInfo.getUserAgent()` returns a `Promise`, so it can't just be string interpolated directly. This fix is pretty much the same as what we do for V1 (see [here](https://github.com/ueat/mobile-apps/blob/main/mobile-apps-template/template/src/screens/OrderingScreen.tsx#L18)), but with an extra `catch` just in case.